### PR TITLE
Update 05.spawning_mobs.rst

### DIFF
--- a/getting_started/first_3d_game/05.spawning_mobs.rst
+++ b/getting_started/first_3d_game/05.spawning_mobs.rst
@@ -242,10 +242,10 @@ Let's code the mob spawning logic. We're going to:
        # We store the reference to the SpawnLocation node.
        var mob_spawn_location = get_node("SpawnPath/SpawnLocation")
        # And give it a random offset.
-       mob_spawn_location.unit_offset = randf()
+       mob_spawn_location.progress_ratio = randf()
 
        var player_position = $Player.transform.origin
-       mob.initialize(mob_spawn_location.translation, player_position)
+       mob.initialize(mob_spawn_location.position, player_position)
 
        add_child(mob)
 
@@ -291,9 +291,9 @@ Here is the complete ``Main.gd`` script so far, for reference.
        var mob = mob_scene.instantiate()
 
        var mob_spawn_location = get_node("SpawnPath/SpawnLocation")
-       mob_spawn_location.unit_offset = randf()
+       mob_spawn_location.progress_ratio = randf()
        var player_position = $Player.transform.origin
-       mob.initialize(mob_spawn_location.translation, player_position)
+       mob.initialize(mob_spawn_location.position, player_position)
 
        add_child(mob)
 


### PR DESCRIPTION
    This is incorrect. Those properties have been renamed, unit_offset of PathFollow3D is now progress_ratio and translation of Node3D is now position.

Updated unit_offset to progress_ratio and translation to position

<!--
Please target the `master` branch in priority.
PRs can target other branches (e.g. `3.2`, `3.5`) if the same change was done in `master`, or is not relevant there.
PRs must not target `stable`, as that branch is updated manually.

The type of content accepted into the documentation is explained here:
https://docs.godotengine.org/en/latest/community/contributing/content_guidelines.html
-->
